### PR TITLE
Added multitenancy support and added some equivalent JPA methods for …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM eclipse-temurin:17-jdk-alpine AS builder
 WORKDIR /app
 COPY . /app
+RUN apk add dos2unix
+RUN dos2unix ./mvnw
 RUN chmod +x ./mvnw
-RUN ./mvnw clean package -DskipTests
+RUN ./mvnw package -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine AS main
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,9 @@ services:
       - softcont-network
 
   thirds_management:
-    image: jeserna/thirds-management:latest
-    #ports:
-    #  - "8081:8080"
+    build: .
+    ports:
+      - "8081:8080"
     environment:
       - DB_USERNAME=springuser
       - DB_PASSWORD=ThePassword

--- a/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/config/WebConfiguration.java
+++ b/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/config/WebConfiguration.java
@@ -1,0 +1,19 @@
+package com.thirdsmanagement.thirds.infrastructure.adapters.config;
+
+import com.thirdsmanagement.thirds.infrastructure.adapters.output.persistence.multitenancy.interceptor.TenantInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+@RequiredArgsConstructor
+@Configuration
+public class WebConfiguration implements WebMvcConfigurer {
+
+    private final TenantInterceptor tenantInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addWebRequestInterceptor(tenantInterceptor);
+    }
+
+}

--- a/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/entity/ThirdEntity.java
+++ b/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/entity/ThirdEntity.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.TenantId;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import com.thirdsmanagement.thirds.domain.model.ePersonType;
@@ -116,5 +117,8 @@ public class ThirdEntity {
     @Column(name = "th_updated_at")
     @UpdateTimestamp
     private LocalDateTime updateDate;
+
+    @TenantId
+    private String tenantId;
 
 }

--- a/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/multitenancy/CurrentTenatIdentifierResolverImpl.java
+++ b/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/multitenancy/CurrentTenatIdentifierResolverImpl.java
@@ -1,0 +1,36 @@
+package com.thirdsmanagement.thirds.infrastructure.adapters.output.persistence.multitenancy;
+
+import com.thirdsmanagement.thirds.infrastructure.adapters.output.persistence.multitenancy.util.TenantContext;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+
+import java.util.Map;
+
+@Component
+class CurrentTenantIdentifierResolverImpl implements CurrentTenantIdentifierResolver, HibernatePropertiesCustomizer {
+
+    @Override
+    public String resolveCurrentTenantIdentifier() {
+        String tenantId = TenantContext.getTenantId();
+        if (!ObjectUtils.isEmpty(tenantId)) {
+            return tenantId;
+        } else {
+            // Allow bootstrapping the EntityManagerFactory, in which case no tenant is needed
+            return "BOOTSTRAP";
+        }
+    }
+
+    @Override
+    public boolean validateExistingCurrentSessions() {
+        return true;
+    }
+
+    @Override
+    public void customize(Map<String, Object> hibernateProperties) {
+        hibernateProperties.put(AvailableSettings.MULTI_TENANT_IDENTIFIER_RESOLVER, this);
+    }
+
+}

--- a/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/multitenancy/async/AsyncConfig.java
+++ b/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/multitenancy/async/AsyncConfig.java
@@ -1,0 +1,32 @@
+package com.thirdsmanagement.thirds.infrastructure.adapters.output.persistence.multitenancy.async;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(7);
+        executor.setMaxPoolSize(42);
+        executor.setQueueCapacity(11);
+        executor.setThreadNamePrefix("TenantAwareTaskExecutor-");
+        executor.setTaskDecorator(new TenantAwareTaskDecorator());
+        executor.initialize();
+
+        return executor;
+    }
+
+}

--- a/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/multitenancy/async/TenantAwareTaskDecorator.java
+++ b/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/multitenancy/async/TenantAwareTaskDecorator.java
@@ -1,0 +1,22 @@
+package com.thirdsmanagement.thirds.infrastructure.adapters.output.persistence.multitenancy.async;
+
+import com.thirdsmanagement.thirds.infrastructure.adapters.output.persistence.multitenancy.util.TenantContext;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.lang.NonNull;
+
+public class TenantAwareTaskDecorator implements TaskDecorator {
+
+    @Override
+    @NonNull
+    public Runnable decorate(@NonNull Runnable runnable) {
+        String tenantId = TenantContext.getTenantId();
+        return () -> {
+            try {
+                TenantContext.setTenantId(tenantId);
+                runnable.run();
+            } finally {
+                TenantContext.setTenantId(null);
+            }
+        };
+    }
+}

--- a/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/multitenancy/interceptor/TenantInterceptor.java
+++ b/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/multitenancy/interceptor/TenantInterceptor.java
@@ -1,0 +1,35 @@
+package com.thirdsmanagement.thirds.infrastructure.adapters.output.persistence.multitenancy.interceptor;
+
+
+import com.thirdsmanagement.thirds.infrastructure.adapters.output.persistence.multitenancy.util.TenantContext;
+import org.springframework.stereotype.Component;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.context.request.WebRequestInterceptor;
+
+@Component
+public class TenantInterceptor implements WebRequestInterceptor {
+    @Override
+    public void preHandle(WebRequest request) throws Exception {
+//        UsernamePasswordAuthenticationToken tokenAuth = (UsernamePasswordAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+//        //Validate the tokenAuth
+//        if(tokenAuth != null){
+//            String tenantId = tokenAuth.getCredentials().toString();
+//            TenantContext.setTenantId(tenantId);
+//        }
+
+        TenantContext.setTenantId("1");
+
+
+    }
+
+    @Override
+    public void postHandle(WebRequest request, ModelMap model) throws Exception {
+        TenantContext.clear();
+    }
+
+    @Override
+    public void afterCompletion(WebRequest request, Exception ex) throws Exception {
+
+    }
+}

--- a/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/multitenancy/util/TenantContext.java
+++ b/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/multitenancy/util/TenantContext.java
@@ -1,0 +1,23 @@
+package com.thirdsmanagement.thirds.infrastructure.adapters.output.persistence.multitenancy.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TenantContext {
+    private TenantContext() {}
+
+    private static final InheritableThreadLocal<String> currentTenant = new InheritableThreadLocal<>();
+
+    public static void setTenantId(String tenantId) {
+        log.debug("Setting tenantId to " + tenantId);
+        currentTenant.set(tenantId);
+    }
+
+    public static String getTenantId() {
+        return currentTenant.get();
+    }
+
+    public static void clear(){
+        currentTenant.remove();
+    }
+}

--- a/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/repository/ThirdRepository.java
+++ b/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/repository/ThirdRepository.java
@@ -14,12 +14,19 @@ public interface ThirdRepository extends JpaRepository<ThirdEntity,Long>{
     @Query("SELECT t FROM ThirdEntity t INNER JOIN t.thirdTypes tt WHERE t.entId = :entId")
     Page<ThirdEntity> getThirdsBy(Long entId, Pageable page);
 
+    Page<ThirdEntity> getThirdsByEntId(Long entId, Pageable page);
+
     @Query("SELECT t FROM ThirdEntity t INNER JOIN t.thirdTypes tt WHERE t.entId = :entId AND t.state = 'false'")
     Page<ThirdEntity> getInactiveThirdsBy(Long entId, Pageable page);
+
+    Page<ThirdEntity> findByEntIdAndStateFalse(Long entId, Pageable page);
 
     @Query("SELECT t FROM ThirdEntity t INNER JOIN t.thirdTypes tt WHERE t.entId = :entId AND t.state = 'true' AND tt.ttName = 'Proveedor'")
     Page<ThirdEntity> getProvidersBy(Long entId, Pageable page);
 
     @Query("SELECT t FROM ThirdEntity t INNER JOIN t.thirdTypes tt WHERE t.entId = :entId AND t.state = 'true' AND tt.ttName = 'Cliente'")
     Page<ThirdEntity> getCustomersBy(Long entId, Pageable page);
+
+    Page<ThirdEntity> findByEntIdAndStateTrueAndThirdTypes_TtName(Long entId, String ttName, Pageable page);
+
 }

--- a/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/repository/ThirdTypeRepository.java
+++ b/src/main/java/com/thirdsmanagement/thirds/infrastructure/adapters/output/persistence/repository/ThirdTypeRepository.java
@@ -10,4 +10,6 @@ import com.thirdsmanagement.thirds.infrastructure.adapters.output.persistence.en
 public interface ThirdTypeRepository extends JpaRepository<ThirdTypeEntity,Long>{
     @Query("SELECT tt FROM ThirdTypeEntity tt WHERE tt.ttName LIKE %:name%")
     List<ThirdTypeEntity> findByName(String name);
+
+    List<ThirdTypeEntity> findByTtNameContaining(String name);
 }


### PR DESCRIPTION
Nota: La característica de multitenencia no funciona con custom queries, todas las consultas que se pueden hacer con las custom queries tienen un equivalente en la convención de JPA: https://docs.spring.io/spring-data/jpa/reference/jpa/query-methods.html, se añadieron algunos métodos equivalentes que pueden ser usados para que JPA genere las consultas y añada el tenantId, cuando tengamos la seguridad podemos establecer como tenatId el subject del usuario autenticado que esta en el SecurityContextHolder, eso lo dejé listo para solo borrar una linea y que funcione sin hacer cambios mayores en la base de codigo